### PR TITLE
mozconfig: ignore more shell variables

### DIFF
--- a/python/mozbuild/mozbuild/mozconfig.py
+++ b/python/mozbuild/mozbuild/mozconfig.py
@@ -74,7 +74,7 @@ class MozconfigLoader(object):
     DEPRECATED_TOPSRCDIR_PATHS = ('mozconfig.sh', 'myconfig.sh')
     DEPRECATED_HOME_PATHS = ('.mozconfig', '.mozconfig.sh', '.mozmyconfig.sh')
 
-    IGNORE_SHELL_VARIABLES = {'_'}
+    IGNORE_SHELL_VARIABLES = {'_', 'LINENO', 'RANDOM'}
 
     ENVIRONMENT_VARIABLES = {
         'CC', 'CXX', 'CFLAGS', 'CXXFLAGS', 'LDFLAGS', 'MOZ_OBJDIR',


### PR DESCRIPTION
NetBSD shell provides `LINENO` and `RANDOM` variables that are volatile and should be ignored.